### PR TITLE
Add riuso key to publiccode.yml file

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -39,6 +39,8 @@ it:
     cie: false
     pagopa: false
     spid: false
+  riuso:
+    codiceIPA: p_bs
 legal:
   license: EUPL-1.2
 localisation:

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -43,6 +43,8 @@ it:
     codiceIPA: p_bs
 legal:
   license: EUPL-1.2
+  mainCopyrightOwner: Provincia di Brescia
+  repoOwner: Provincia di Brescia
 localisation:
   availableLanguages:
     - it


### PR DESCRIPTION
Buongiorno @provincia-brescia,

questa PR:
* aggiunge la chiave `codiceIPA` all'interno della chiave `riuso` nel file `publiccode.yml`;
* aggiunge le chiavi relative agli owner.
In questo modo sarà possibile visualizzare correttamente il nome dell'ente nel catalogo.

Resto a disposizione.
Grazie